### PR TITLE
Changed Uglyify to output a Source Map file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,8 @@ module.exports = function(grunt) {
     uglify: {
        options: {
           preserveComments: 'some',
+          sourceMap: 'dist/ng-bs-daterangepicker.min.js.map',
+          sourceMappingURL: 'ng-bs-daterangepicker.min.js.map',
           report: 'min'
        },
        dist: {


### PR DESCRIPTION
Grunt will now build a ng-bs-daterangepicker.min.js.map file, to aid in debugging.
