### PR TITLE
Problem with directive "require" property affecting all inputs 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
             'src/components/angular/angular.js',
             'src/components/angular-mocks/angular-mocks.js',
             'src/components/bootstrap/dist/js/bootstrap.js',
-            'src/components/bootstrap-daterangepicker/moment.js',
+            'src/components/momentjs/min/moment.min.js',
             'src/components/bootstrap-daterangepicker/daterangepicker.js',
             'src/ng-bs-daterangepicker.js',
             'test/**/*.js']

--- a/src/ng-bs-daterangepicker.html
+++ b/src/ng-bs-daterangepicker.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" type="text/css" href="components/bootstrap-daterangepicker/daterangepicker-bs3.css">
 <script type="text/javascript" src="components/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="components/bootstrap/dist/js/bootstrap.min.js"></script>
-<script type="text/javascript" src="components/bootstrap-daterangepicker/moment.min.js"></script>
+<script type="text/javascript" src="components/momentjs/min/moment.min.js"></script>
 <script type="text/javascript" src="components/bootstrap-daterangepicker/daterangepicker.js"></script>
 <script type="text/javascript" src="components/angular/angular.min.js"></script>
 <script type="text/javascript" src="ng-bs-daterangepicker.js"></script>

--- a/src/ng-bs-daterangepicker.js
+++ b/src/ng-bs-daterangepicker.js
@@ -9,9 +9,9 @@
 angular.module('ngBootstrap', []).directive('input', function ($compile, $parse) {
 	return {
 		restrict: 'E',
-		require: 'ngModel',
+		require: '?ngModel',
 		link: function ($scope, $element, $attributes, ngModel) {
-			if ($attributes.type !== 'daterange') return;
+			if ($attributes.type !== 'daterange' || ngModel === null ) return;
 
 			var options = {};
 			options.format = $attributes.format || 'YYYY-MM-DD';


### PR DESCRIPTION
fixed ngModel declaration to be optional so it fits default requirement of angular "input" directive definition. Declaring a required ngModel in this module had a side effect on all inputs in application, even if they are not related to the datepicker.

also the test was broken because of momentjs that was not properly included
