### PR TITLE
Update ng-bs-daterangepicker.js

### DIFF
--- a/src/ng-bs-daterangepicker.js
+++ b/src/ng-bs-daterangepicker.js
@@ -50,8 +50,8 @@ angular.module('ngBootstrap', []).directive('input', function ($compile, $parse)
 					ngModel.$setViewValue({ startDate: moment().startOf('day'), endDate: moment().startOf('day') });
 					return;
 				}
-				$element.data('daterangepicker').startDate = modelValue.startDate;
-				$element.data('daterangepicker').endDate = modelValue.endDate;
+				$element.data('daterangepicker').setStartDate(modelValue.startDate);
+				$element.data('daterangepicker').setEndDate(modelValue.endDate);
 				$element.data('daterangepicker').updateView();
 				$element.data('daterangepicker').updateCalendars();
 				$element.data('daterangepicker').updateInputText();


### PR DESCRIPTION
Fixed bug with setting start and end dates. You should not change those dates directly and use setters instead. That caused the bug that oldStartDate and oldEndDate not setted.