### PR TITLE
Add full support for timepicker.

### DIFF
--- a/src/ng-bs-daterangepicker.js
+++ b/src/ng-bs-daterangepicker.js
@@ -22,15 +22,19 @@ angular.module('ngBootstrap', []).directive('input', function ($compile, $parse,
 			options.ranges = $attributes.ranges && $parse($attributes.ranges)($scope);
 			options.locale = $attributes.locale && $parse($attributes.locale)($scope);
 			options.opens = $attributes.opens && $parse($attributes.opens)($scope);
-			options.timePicker = $attributes.enabletimepicker && $parse($attributes.enabletimepicker)($scope);
-
-                        function datify(date){
-                            return moment.isMoment(date) ? date.toDate() : date;
-                        }
-                        
-                        function momentify (date){
-                            return moment.isMoment(date) ? moment(date) : date;
-                        }
+			
+			if ($attributes.enabletimepicker) {
+				options.timePicker = true;
+				angular.extend(options, $parse($attributes.enabletimepicker)($scope));
+            }
+			
+			function datify(date){
+				return moment.isMoment(date) ? date.toDate() : date;
+			}
+			
+			function momentify (date){
+				return moment.isMoment(date) ? moment(date) : date;
+			}
                         
 			function format(date) {
 				return $filter('date')(datify(date), options.format.replace(/Y/g, 'y').replace(/D/g, 'd')); //date.format(options.format);


### PR DESCRIPTION
With the current implementation the time picker 1) isn't displayed if you set it to true and 2) you have no way of setting the timepicker options.

The idea here is that you pass a json object to the attribute which has the timepicker properties that are supported by the underlying source component like so:

``` javascript
<input .... enabletimepicker="{ timePickerIncrement: 5, timePicker12Hour: false }" />

```