### PR TITLE
Remove unnecessary dependency declarations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,11 +4,9 @@
   "version": "0.0.5",
   "main": "./src/ng-bs-daterangepicker.js",
   "dependencies": {
-    "jquery": "latest",
     "angular": ">= 1.0.7",
     "bootstrap-daterangepicker": "1.3.17",
-    "bootstrap": "~3.0.0",
-    "momentjs": "< 2.9.0"
+    "bootstrap": "~3.0.0"
   },
   "devDependencies": {
     "angular-mocks": ">= 1.0.7"

--- a/example/index.html
+++ b/example/index.html
@@ -38,7 +38,7 @@
 
 		<script src="../bower_components/jquery/dist/jquery.js"></script>
 		<script src="../bower_components/bootstrap/dist/js/bootstrap.js"></script>
-		<script src="../bower_components/momentjs/moment.js"></script>
+		<script src="../bower_components/moment/moment.js"></script>
 		<script src="../bower_components/bootstrap-daterangepicker/daterangepicker.js"></script>
 		<script src="../bower_components/angular/angular.js"></script>
 


### PR DESCRIPTION
The dependencies are already specified in the bootstrap-datepickerpicker bower.json file. They don't need to be re-specified.