### PR TITLE
Replace deprecated methods

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "main": "./src/ng-bs-daterangepicker.js",
   "dependencies": {
     "angular": ">= 1.0.7",
-    "bootstrap-daterangepicker": "1.3.17",
+    "bootstrap-daterangepicker": "1.3.23",
     "bootstrap": "~3.0.0"
   },
   "devDependencies": {

--- a/example/index.html
+++ b/example/index.html
@@ -53,9 +53,9 @@
 						$scope.dates4 = { startDate: moment().subtract(1, 'day'), endDate: moment().subtract(1, 'day') };
 						$scope.ranges = {
 							'Today': [moment(), moment()],
-							'Yesterday': [moment().subtract('days', 1), moment().subtract('days', 1)],
-							'Last 7 days': [moment().subtract('days', 7), moment()],
-							'Last 30 days': [moment().subtract('days', 30), moment()],
+							'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+							'Last 7 days': [moment().subtract(7, 'days'), moment()],
+							'Last 30 days': [moment().subtract(30, 'days'), moment()],
 							'This month': [moment().startOf('month'), moment().endOf('month')]
 						};
 					});


### PR DESCRIPTION
Moved bootstrap-datarangepicker to v1.3.23 and refactored example controller ($scope.ranges [subtract function])