### PR TITLE
Avoid [Object object] in the input for old Angular versions (#82)

### DIFF
--- a/src/ng-bs-daterangepicker.js
+++ b/src/ng-bs-daterangepicker.js
@@ -12,6 +12,7 @@
 		.directive('input', ['$compile', '$parse', '$filter', function($compile, $parse, $filter) {
 			return {
 				restrict: 'E',
+				priority: 1,
 				require: '?ngModel',
 				link: function($scope, $element, $attributes, ngModel) {
 


### PR DESCRIPTION
at least for v1.2.16
